### PR TITLE
Un-parametrize syntax and semantics

### DIFF
--- a/configScript.sml
+++ b/configScript.sml
@@ -1,0 +1,31 @@
+
+open HolKernel Parse boolLib bossLib term_tactic;
+open arithmeticTheory integerTheory stringTheory optionTheory;
+
+val _ = new_theory "config";
+
+(*
+ * A basic configuration that supports integers and strings. This configuration
+ * is hardcoded into the types defined in [{exp,value,pure_lang}Script.sml].
+ *)
+
+Datatype:
+  lit = Int int
+      | Str string
+End
+
+Datatype:
+  atom = Add | Concat | Length
+End
+
+Definition atom_op_def:
+  atom_op op args =
+    case (op, args) of
+      (Add, [Int x; Int y]) => SOME (Int (x + y))
+    | (Concat, [Str s; Str t]) => SOME (Str (STRCAT s t))
+    | (Length, [Str s]) => SOME (Int &(STRLEN s))
+    | _ => NONE
+End
+
+val _ = export_theory ();
+

--- a/configScript.sml
+++ b/configScript.sml
@@ -4,28 +4,24 @@ open arithmeticTheory integerTheory stringTheory optionTheory;
 
 val _ = new_theory "config";
 
+(* Configuration record for the parametric atoms.
+   parAtomOp:
+     It takes an element of type 'a (from AtomOp) and returns a
+     function that takes a "'b list" element and SOME b if the
+     number of arguments is correct, NONE otherwise
+*)
+
+Datatype:
+  conf = <| parAtomOp  : 'a -> 'b list -> 'b option; |>
+End
+
 (*
- * A basic configuration that supports integers and strings. This configuration
- * is hardcoded into the types defined in [{exp,value,pure_lang}Script.sml].
+ * Assume an abstract configuration exists.
  *)
 
-Datatype:
-  lit = Int int
-      | Str string
-End
-
-Datatype:
-  atom = Add | Concat | Length
-End
-
-Definition atom_op_def:
-  atom_op op args =
-    case (op, args) of
-      (Add, [Int x; Int y]) => SOME (Int (x + y))
-    | (Concat, [Str s; Str t]) => SOME (Str (STRCAT s t))
-    | (Length, [Str s]) => SOME (Int &(STRLEN s))
-    | _ => NONE
-End
+val atom_op_ty = new_type ("atom_op", 0);
+val atom_lit_ty = new_type ("lit", 0);
+val the_config = new_constant ("config", “:(atom_op, lit) conf”);
 
 val _ = export_theory ();
 

--- a/ctxt_equivScript.sml
+++ b/ctxt_equivScript.sml
@@ -8,18 +8,18 @@ val _ = new_theory "ctxt_equiv";
 
 Datatype:
   ctxt = Hole
-       | Prim (('a,'b) op) (('a,'b) exp list) ctxt (('a,'b) exp list)
-       | AppL ctxt (('a,'b) exp)
-       | AppR (('a,'b) exp) ctxt
+       | Prim op (exp list) ctxt (exp list)
+       | AppL ctxt exp
+       | AppR exp ctxt
        | Lam vname ctxt
-       | LetrecL ((fname # vname # (('a,'b) exp)) list)
+       | LetrecL ((fname # vname # exp) list)
                   (fname # vname # ctxt)
-                 ((fname # vname # (('a,'b) exp)) list) (('a,'b) exp)
-       | LetrecR ((fname # vname # ('a,'b) exp) list) ctxt
-       | CaseL ctxt vname ((vname # vname list # ('a,'b) exp) list)
-       | CaseR (('a,'b) exp) vname ((vname # vname list # ('a,'b) exp) list)
-                                    (vname # vname list # ctxt)
-                                   ((vname # vname list # ('a,'b) exp) list)
+                 ((fname # vname # exp) list) exp
+       | LetrecR ((fname # vname # exp) list) ctxt
+       | CaseL ctxt vname ((vname # vname list # exp) list)
+       | CaseR exp vname ((vname # vname list # exp) list)
+                          (vname # vname list # ctxt)
+                         ((vname # vname list # exp) list)
 End
 
 Definition plug_def:
@@ -36,15 +36,15 @@ Definition plug_def:
 End
 
 Definition exp_sim_def:
-  exp_sim c x y ⇔
+  exp_sim x y ⇔
     ∀bindings.
       set (freevars x) ∪ set (freevars y) ⊆ set (MAP FST bindings) ⇒
-      exp_rel c (bind bindings x) (bind bindings y)
+      exp_rel (bind bindings x) (bind bindings y)
 End
 
 Theorem exp_sim_closed:
   closed x ∧ closed y ⇒
-  exp_sim c x y = exp_rel c x y
+  exp_sim x y = exp_rel x y
 Proof
   fs [closed_def,exp_sim_def,bind_def]
   \\ rw [] \\ eq_tac \\ rw []
@@ -75,7 +75,7 @@ Proof
 QED
 
 Theorem exp_sim_Lam:
-  exp_sim c x y ⇒ exp_sim c (Lam s x) (Lam s y)
+  exp_sim x y ⇒ exp_sim (Lam s x) (Lam s y)
 Proof
   fs [exp_sim_def] \\ rw []
   \\ fs [bind_Lam]
@@ -91,7 +91,7 @@ Proof
 QED
 
 Theorem exp_sim_plug:
-  ∀h x y. exp_sim c x y ⇒ exp_sim c (plug h x) (plug h y)
+  ∀h x y. exp_sim x y ⇒ exp_sim (plug h x) (plug h y)
 Proof
   ho_match_mp_tac plug_ind \\ rw []
   THEN1 (rename [‘Hole’] \\ fs [plug_def])

--- a/expScript.sml
+++ b/expScript.sml
@@ -1,7 +1,6 @@
 
 open HolKernel Parse boolLib bossLib term_tactic;
-open arithmeticTheory listTheory stringTheory alistTheory optionTheory
-     ltreeTheory llistTheory bagTheory quotient_llistTheory;
+open stringTheory optionTheory configTheory ;
 
 val _ = new_theory "exp";
 
@@ -10,30 +9,18 @@ val _ = new_theory "exp";
 Type vname = “:string”  (* variable name *)
 Type fname = “:string”  (* function name *)
 
-(*configuration record for the parametric atoms.
-
-   parAtomOp:
-     It takes an element of type 'a (from AtomOp) and returns a
-     function that takes a "'b list" element and SOME b if the
-     number of arguments is correct, NONE otherwise
-
-*)
 Datatype:
-  conf = <| parAtomOp  : 'a -> 'b list -> 'b option; |>
-End
-
-Datatype:
-  op = If               (* if-expression                            *)
-     | Cons string      (* datatype constructor                     *)
-     | IsEq string num  (* compare cons tag and num of args         *)
-     | Proj string num  (* reading a field of a constructor         *)
-     | AtomOp 'a        (* primitive parametric operator over Atoms *)
-     | Lit 'b           (* parametric literal Atom                  *)
+  op = If                 (* if-expression                            *)
+     | Cons string        (* datatype constructor                     *)
+     | IsEq string num    (* compare cons tag and num of args         *)
+     | Proj string num    (* reading a field of a constructor         *)
+     | AtomOp config$atom (* primitive parametric operator over Atoms *)
+     | Lit config$lit     (* parametric literal Atom                  *)
 End
 
 Datatype:
   exp = Var vname                     (* variable                   *)
-      | Prim (('a,'b) op) (exp list)  (* primitive operations       *)
+      | Prim op (exp list)            (* primitive operations       *)
       | App exp exp                   (* function application       *)
       | Lam vname exp                 (* lambda                     *)
       | Letrec ((fname # vname # exp) list) exp   (* mut. rec. funs *)

--- a/expScript.sml
+++ b/expScript.sml
@@ -14,8 +14,8 @@ Datatype:
      | Cons string        (* datatype constructor                     *)
      | IsEq string num    (* compare cons tag and num of args         *)
      | Proj string num    (* reading a field of a constructor         *)
-     | AtomOp config$atom (* primitive parametric operator over Atoms *)
-     | Lit config$lit     (* parametric literal Atom                  *)
+     | AtomOp atom_op     (* primitive parametric operator over Atoms *)
+     | Lit lit            (* parametric literal Atom                  *)
 End
 
 Datatype:

--- a/pure_ioScript.sml
+++ b/pure_ioScript.sml
@@ -12,7 +12,7 @@ Datatype:
 End
 
 Datatype:
-  next_res = Act 'e ((('a,'b) v) list) | Ret | Div | Err
+  next_res = Act 'e (v list) | Ret | Div | Err
 End
 
 Inductive next:
@@ -29,9 +29,9 @@ Inductive next:
   (∀v.
     next (Constructor "Ret" [v], []) Ret)
   ∧
-  (∀v f n c e x stack res.
-    dest_Closure f = SOME (n,e) ∧ eval c x = v ∧
-    next (eval c (bind [(n,x)] e), stack) res ⇒
+  (∀v f n e x stack res.
+    dest_Closure f = SOME (n,e) ∧ eval x = v ∧
+    next (eval (bind [(n,x)] e), stack) res ⇒
     next (Constructor "Ret" [v], f::stack) res)
   ∧
   (∀v stack.
@@ -50,15 +50,15 @@ Definition next_action_def:
 End
 
 Definition continue_def:
-  continue c [] k = INL T ∧
-  continue c (f::stack) k =
+  continue [] k = INL T ∧
+  continue (f::stack) k =
     case dest_Closure f of
     | NONE => INL F
-    | SOME (n,e) => INR (eval c (bind [(n,Lit k)] e), stack)
+    | SOME (n,e) => INR (eval (bind [(n,Lit k)] e), stack)
 End
 
 Definition interp'_def:
-  interp' c =
+  interp' =
     io_unfold
       (λi. case i of
            | INL T => Ret' Termination
@@ -68,29 +68,29 @@ Definition interp'_def:
              | Ret => Ret' Termination
              | Err => Ret' Error
              | Div => Ret' SilentDivergence
-             | Act a new_stack => Vis' a (continue c new_stack))
+             | Act a new_stack => Vis' a (continue new_stack))
 End
 
 Definition interp_def:
-  interp c v stack = interp' c (INR (v, stack))
+  interp v stack = interp' (INR (v, stack))
 End
 
 Theorem interp_def:
-  interp c v stack =
+  interp v stack =
     case next_action (v,stack) of
     | Ret => Ret Termination
     | Div => Ret SilentDivergence
     | Err => Ret Error
     | Act a new_stack =>
-        Vis a (λk. case continue c new_stack k of
+        Vis a (λk. case continue new_stack k of
                    | INL b => Ret (if b then Termination else Error)
-                   | INR (v,stack) => interp c v stack)
+                   | INR (v,stack) => interp v stack)
 Proof
   fs [Once interp_def,interp'_def]
   \\ once_rewrite_tac [io_unfold] \\ fs []
   \\ Cases_on ‘next_action (v,stack)’ \\ fs []
   \\ fs [combinTheory.o_DEF,FUN_EQ_THM] \\ rw []
-  \\ Cases_on ‘continue c l k’ \\ fs []
+  \\ Cases_on ‘continue l k’ \\ fs []
   THEN1
    (once_rewrite_tac [io_unfold] \\ fs []
     \\ IF_CASES_TAC \\ fs [])
@@ -99,7 +99,7 @@ Proof
 QED
 
 Definition semantics_def:
-  semantics c e binds = interp c (eval c e) (MAP (eval c) binds)
+  semantics e binds = interp (eval e) (MAP eval binds)
 End
 
 (* TODO: derive nice equations for reasoning about semantics *)

--- a/pure_langScript.sml
+++ b/pure_langScript.sml
@@ -125,7 +125,7 @@ Definition eval_op_def:
   (eval_op (Proj s i) [x] = el s i x) ∧
   (eval_op (AtomOp a) xs =
      if MEM Diverge xs then Diverge else
-       case OPTION_BIND (getAtoms xs) (config$atom_op a) of
+       case OPTION_BIND (getAtoms xs) (config.parAtomOp a) of
           SOME b => Atom b
         | _      => Error )  ∧
   (eval_op (Lit b) [] = Atom b) ∧
@@ -1377,7 +1377,7 @@ Theorem eval_PrimOp:
   eval (Prim (AtomOp a) es) =
   (let xs = MAP eval es in
    if MEM Diverge xs then Diverge else
-      case OPTION_BIND (getAtoms xs) (atom_op a) of
+      case OPTION_BIND (getAtoms xs) (config.parAtomOp a) of
        | (SOME n) => Atom n
        | _        => Error)
 Proof

--- a/v_quotientScript.sml
+++ b/v_quotientScript.sml
@@ -5,139 +5,44 @@ open HolKernel pure_langTheory valueTheory quotient_llistTheory listTheory
 
 val _ = new_theory "v_quotient";
 
-(*
- * We won't be able to use `v_rel c` with `c` free as the relation
- * for our quotient type, so we make up a dummy value in place of c,
- * and define a new relation `vq_rel`.
- *)
-
-Definition empty_conf_def:
-  empty_conf = ARB : ('a, 'b) conf
-End
-
-Definition vq_rel_def:
-  vq_rel = v_rel empty_conf
-End
-
-Theorem vq_rel_refl:
-  ∀x. vq_rel x x
-Proof
-  simp [vq_rel_def, v_rel_refl]
-QED
-
-Theorem vq_rel_sym:
-  ∀x y. vq_rel x y ⇔ vq_rel y x
-Proof
-  simp [vq_rel_def, v_rel_sym]
-QED
-
-Theorem vq_rel_trans:
-  ∀x y z. vq_rel x y ∧ vq_rel y z ⇒ vq_rel x z
-Proof
-  metis_tac [vq_rel_def, v_rel_trans]
-QED
-
-Theorem vq_rel_EQUIV:
-  EQUIV vq_rel
+Theorem v_rel_EQUIV:
+  EQUIV v_rel
 Proof
   simp [EQUIV_def, FUN_EQ_THM]
-  \\ metis_tac [vq_rel_sym, vq_rel_trans, vq_rel_refl]
+  \\ metis_tac [v_rel_sym, v_rel_trans, v_rel_refl]
 QED
-
-Definition vq_eval_def:
-  vq_eval = eval empty_conf
-End
-
-Definition vq_exp_rel_def:
-  vq_exp_rel x y = exp_rel empty_conf x y
-End
-
-Theorem vq_exp_rel = vq_exp_rel_def;
-
-(*
- * Adapt theorems about v_rel to vq_rel.
- *)
-
-Theorem vq_rel_rules =
-  v_rel_rules
-  |> CONJUNCTS
-  |> map (Q.SPEC ‘empty_conf’)
-  |> LIST_CONJ
-  |> REWRITE_RULE [
-    GSYM vq_rel_def,
-    GSYM vq_eval_def];
-
-Theorem vq_rel_rules' =
-  v_rel_rules'
-  |> CONJUNCTS
-  |> map (Q.SPEC ‘empty_conf’)
-  |> LIST_CONJ
-  |> REWRITE_RULE [
-    GSYM vq_rel_def,
-    GSYM vq_eval_def];
-
-Theorem vq_rel_cases =
-  v_rel_cases
-  |> CONJUNCTS
-  |> map (Q.SPEC ‘empty_conf’)
-  |> LIST_CONJ
-  |> REWRITE_RULE [
-    GSYM vq_rel_def,
-    GSYM vq_eval_def,
-    GSYM vq_exp_rel_def];
-
-Theorem vq_exp_rel_def:
-  vq_exp_rel x y = vq_rel (vq_eval x) (vq_eval y)
-Proof
-  rw [vq_exp_rel_def, vq_rel_def, vq_eval_def, exp_rel_def]
-QED
-
-(*
- * Adapt theorems about eval to vq_eval.
- *)
-
-Theorem eval_thm:
-  eval c Fail = Error ∧
-  eval c (Var s) = Error ∧
-  eval c (Cons s xs) =
-    Constructor s (MAP (eval c) xs) ∧
-  eval c (IsEq s n x) = is_eq c s n (eval c x) ∧
-  eval c (Proj s i x) = el s i (eval c x) ∧
-  eval c (Let s x y) = eval c (bind [(s,x)] y) ∧
-  eval c (If x y z) =
-   (if v_rel c (eval c x) Diverge then Diverge
-    else if v_rel c (eval c x) True then eval c y
-    else if v_rel c (eval c x) False then eval c z
-    else Error) ∧
-  eval c (Lam s x) = Closure s x ∧
-  eval c (Letrec f x) = eval c (subst_funs f x) ∧
-  eval c (Case x nm css) = eval c (expandCases x nm css)
-Proof
-  gs [eval_thm, v_rel_cases, PURE_ONCE_REWRITE_RULE [v_rel_sym] v_rel_cases]
-QED
-
-Theorem vq_eval_thm =
-  eval_thm
-  |> Q.INST [‘c’|->‘empty_conf’]
-  |> REWRITE_RULE [
-    GSYM vq_rel_def,
-    GSYM vq_eval_def];
-
-Theorem vq_progress_lemma =
-  progress_lemma
-  |> Q.INST [‘c’|->‘empty_conf’]
-  |> REWRITE_RULE [
-       exp_rel_def,
-       GSYM vq_rel_def,
-       GSYM vq_eval_def];
 
 Theorem isClos_is_Closure:
-  ∀v. isClos v ⇔ ∃s x. vq_rel v (Closure s x)
+  ∀v. isClos v ⇔ ∃s x. v_rel v (Closure s x)
 Proof
   Cases
-  \\ rw [isClos_def, vq_rel_cases, vq_exp_rel_def]
+  \\ rw [isClos_def, v_rel_cases, exp_rel_def]
   \\ Q.LIST_EXISTS_TAC [‘n’, ‘x’]
-  \\ simp [vq_rel_refl]
+  \\ simp [v_rel_refl]
+QED
+
+(*
+ * The eval_thm theorem adapted for lifting.
+ *)
+
+Theorem eval_lift:
+  eval Fail = Error ∧
+  eval (Var s) = Error ∧
+  eval (Cons s xs) = Constructor s (MAP eval xs) ∧
+  eval (IsEq s n x) = is_eq s n (eval x) ∧
+  eval (Proj s i x) = el s i (eval x) ∧
+  eval (Let s x y) = eval (bind [(s,x)] y) ∧
+  eval (If x y z) =
+    (if v_rel (eval x) Diverge then Diverge
+     else if v_rel (eval x) True then eval y
+     else if v_rel (eval x) False then eval z
+     else Error) ∧
+  eval (Lam s x) = Closure s x ∧
+  eval (Letrec f x) = eval (subst_funs f x) ∧
+  eval (Case x nm css) = eval (expandCases x nm css)
+Proof
+  simp [eval_thm, v_rel_cases,
+        PURE_ONCE_REWRITE_RULE [v_rel_sym] v_rel_cases]
 QED
 
 (*
@@ -147,25 +52,25 @@ QED
  *)
 
 Theorem Atom_vq_11:
-  vq_rel (Atom x) (Atom y) ⇔
+  v_rel (Atom x) (Atom y) ⇔
     x = y
 Proof
-  rw [vq_rel_cases, EQ_SYM_EQ]
+  rw [v_rel_cases, EQ_SYM_EQ]
 QED
 
 Theorem Constructor_vq_11:
-  vq_rel (Constructor n x) (Constructor m y) ⇔
+  v_rel (Constructor n x) (Constructor m y) ⇔
     n = m ∧
-    LIST_REL vq_rel x y
+    LIST_REL v_rel x y
 Proof
-  rw [vq_rel_cases, EQ_SYM_EQ]
+  rw [v_rel_cases, EQ_SYM_EQ]
 QED
 
 Theorem Closure_vq_11:
-  vq_rel (Closure n e1) (Closure m e2) ⇔
-    ∀z. vq_rel (vq_eval (bind [(n, z)] e1)) (vq_eval (bind [(m, z)] e2))
+  v_rel (Closure n e1) (Closure m e2) ⇔
+    ∀z. v_rel (eval (bind [(n, z)] e1)) (eval (bind [(m, z)] e2))
 Proof
-  rw [vq_rel_cases, vq_exp_rel_def]
+  rw [v_rel_cases, exp_rel_def]
 QED
 
 (*
@@ -174,46 +79,41 @@ QED
 
 Theorem Constructor_rsp:
   x1 = y1 ∧
-  LIST_REL vq_rel x2 y2 ⇒
-    vq_rel (Constructor x1 x2) (Constructor y1 y2)
+  LIST_REL v_rel x2 y2 ⇒
+    v_rel (Constructor x1 x2) (Constructor y1 y2)
 Proof
   rw [Constructor_vq_11]
 QED
 
 Theorem vq_eval_rsp:
   x1 = x2 ⇒
-    vq_rel (vq_eval x1) (vq_eval x2)
+    v_rel (eval x1) (eval x2)
 Proof
-  metis_tac [vq_rel_EQUIV, EQUIV_def]
+  simp [v_rel_refl]
 QED
 
 Theorem is_eq_rsp:
-  c1 = c2 ∧
-  x1 = y1 ∧
-  n1 = n2 ∧
-  vq_rel x2 y2 ⇒
-    vq_rel (is_eq c1 x1 n1 x2) (is_eq c2 y1 n2 y2)
+  v_rel x y ⇒
+    v_rel (is_eq s n x) (is_eq s n y)
 Proof
   rw [is_eq_def]
-  \\ fs [vq_rel_refl, vq_rel_cases]
-  \\ rpt CASE_TAC \\ gs [vq_rel_cases, LIST_REL_EL_EQN]
+  \\ fs [v_rel_refl, v_rel_cases]
+  \\ rpt CASE_TAC \\ gs [v_rel_cases, LIST_REL_EL_EQN]
 QED
 
 Theorem el_rsp:
-  x1 = y1 ∧
-  x2 = y2 ∧
-  vq_rel x3 y3 ⇒
-    vq_rel (el x1 x2 x3) (el y1 y2 y3)
+  v_rel x y ⇒
+    v_rel (el s n x) (el s n y)
 Proof
   rw [el_def]
-  \\ fs [vq_rel_cases]
-  \\ rpt CASE_TAC \\ gs [vq_rel_cases, LIST_REL_EL_EQN]
+  \\ fs [v_rel_cases]
+  \\ rpt CASE_TAC \\ gs [v_rel_cases, LIST_REL_EL_EQN]
 QED
 
 Theorem isClos_rsp:
-  ∀x y. vq_rel x y ⇒ isClos x = isClos y
+  ∀x y. v_rel x y ⇒ isClos x = isClos y
 Proof
-  Cases \\ Cases \\ simp [vq_rel_def, v_rel_cases, isClos_def]
+  Cases \\ Cases \\ simp [v_rel_cases, isClos_def]
 QED
 
 (*
@@ -253,7 +153,7 @@ val defs_Constructors : def list = [
 val defs_Functions : def list = [
     {def_name = "eval_vq_def",
      fname    = "eval_vq",
-     func     = “vq_eval”,
+     func     = “eval”,
      fixity   = NONE},
     {def_name = "isClos_vq_def",
      fname    = "is_Clos_vq",
@@ -274,11 +174,11 @@ val [
     Closure_vq_11,
     eval_vq_thm,
     progress_vq_thm,
-    vq_isClos_is_Closure,
-    vq_exp_rel_thm
+    isClos_vq_is_Closure,
+    exp_rel_thm
   ] = define_quotient_types_full {
   types =
-    [{equiv = vq_rel_EQUIV,
+    [{equiv = v_rel_EQUIV,
       name  = "vq"}
     ],
   defs = defs_Constructors @
@@ -298,10 +198,10 @@ val [
   old_thms = [
     Constructor_vq_11,
     Closure_vq_11,
-    vq_eval_thm,
-    vq_progress_lemma,
+    eval_lift,
+    progress_lemma,
     isClos_is_Closure,
-    vq_exp_rel_def
+    exp_rel_def
     ]
   };
 
@@ -309,8 +209,7 @@ Theorem progress_vq_def =
   progress_def
   |> Q.SPEC ‘empty_conf’
   |> REWRITE_RULE [
-    GSYM vq_exp_rel,
-    vq_exp_rel_thm];
+    exp_rel_thm];
 
 Theorem progress_vq_thm =
   progress_vq_thm

--- a/valueScript.sml
+++ b/valueScript.sml
@@ -6,7 +6,7 @@ open arithmeticTheory listTheory stringTheory alistTheory optionTheory
 val _ = new_theory "value";
 
 Datatype:
-  v_prefix = Atom' config$lit
+  v_prefix = Atom' lit
            | Constructor' string
            | Closure' vname exp
            | Diverge'

--- a/valueScript.sml
+++ b/valueScript.sml
@@ -1,26 +1,14 @@
 
 open HolKernel Parse boolLib bossLib term_tactic;
 open arithmeticTheory listTheory stringTheory alistTheory optionTheory
-     ltreeTheory llistTheory bagTheory quotient_llistTheory expTheory;
+     ltreeTheory llistTheory configTheory expTheory quotient_llistTheory;
 
 val _ = new_theory "value";
 
-(* Value type for a call-by-name semantics in a denotational semantics style *)
-
-(* would like to have:
-Codatatype:
-  ('a,'b) v = Atom 'b
-          | Constructor string (('a,'b) v) list)
-          | Closure vname ('a exp)
-          | Diverge
-          | Error
-End
-*)
-
 Datatype:
-  v_prefix = Atom' 'b
+  v_prefix = Atom' config$lit
            | Constructor' string
-           | Closure' vname (('a,'b) exp)
+           | Closure' vname exp
            | Diverge'
            | Error'
 End
@@ -201,7 +189,7 @@ Proof
         \\ irule v_rep_ok_Constructor)
   \\ unabbrev_all_tac
   \\ fs [v_abs_11, Constructor_rep_11]
-  \\ ‘INJ v_rep (set t1 ∪ set t2) 𝕌(:('a,'b) v_prefix ltree)’
+  \\ ‘INJ v_rep (set t1 ∪ set t2) 𝕌(:v_prefix ltree)’
     by simp [pred_setTheory.INJ_DEF, v_rep_11]
   \\ drule INJ_MAP_EQ \\ fs []
 QED
@@ -355,11 +343,11 @@ QED
 
 Theorem datatype_v:
   DATATYPE ((v
-             (Atom : 'b -> ('a, 'b) v)
-             (Constructor : string -> ('a, 'b) v list -> ('a, 'b) v)
-             (Closure : string -> ('a, 'b) exp -> ('a, 'b) v)
-             (Diverge : ('a, 'b) v)
-             (Error : ('a, 'b) v)) : bool)
+             (Atom : config$lit -> v)
+             (Constructor : string -> v list -> v)
+             (Closure : string -> exp -> v)
+             (Diverge : v)
+             (Error : v)) : bool)
 Proof
   rw [boolTheory.DATATYPE_TAG_THM]
 QED
@@ -424,8 +412,6 @@ Proof
   qexists_tac `[h]` >> fs[ltree_lookup_def]
 QED
 
-fun swap_alpha_beta th = th |> INST_TYPE [alpha |-> beta, beta |-> alpha];
-
 Theorem v_bisimulation:
   ∀v1 v2.
     v1 = v2 ⇔
@@ -451,7 +437,7 @@ Proof
   qexists_tac `λv1 v2. R (v_abs v1) (v_abs v2)` >> fs[v_absrep] >>
   rpt gen_tac >> strip_tac >>
   fs[GSYM v_rep_11] >>
-  assume_tac (v_rep_ok_Atom |> swap_alpha_beta) >>
+  assume_tac v_rep_ok_Atom >>
   assume_tac v_rep_ok_Constructor >>
   assume_tac v_rep_ok_Closure >>
   assume_tac v_rep_ok_Diverge >>
@@ -496,14 +482,14 @@ Definition v_to_prefix_def:
 End
 
 Theorem v_to_prefix:
-  (∀a. v_to_prefix (Atom a) = Atom' a : (α,β) v_prefix) ∧
-  (∀c vs. v_to_prefix (Constructor c vs) = Constructor' c : (α,β) v_prefix) ∧
-  (∀x body. v_to_prefix (Closure x body) = Closure' x body : (α,β) v_prefix) ∧
-  v_to_prefix Diverge = Diverge' : (α,β) v_prefix ∧
-  v_to_prefix Error = Error' : (α,β) v_prefix
+  (∀a. v_to_prefix (Atom a) = Atom' a) ∧
+  (∀c vs. v_to_prefix (Constructor c vs) = Constructor' c) ∧
+  (∀x body. v_to_prefix (Closure x body) = Closure' x body) ∧
+  v_to_prefix Diverge = Diverge' ∧
+  v_to_prefix Error = Error'
 Proof
   fs[Atom_def, Constructor_def, Closure_def, Diverge_def, Error_def] >>
-  assume_tac (v_rep_ok_Atom |> swap_alpha_beta) >>
+  assume_tac v_rep_ok_Atom >>
   assume_tac v_rep_ok_Constructor >>
   assume_tac v_rep_ok_Closure >>
   assume_tac v_rep_ok_Diverge >>
@@ -521,9 +507,9 @@ Definition v_lookup_def:
 End
 
 Theorem v_lookup_alt:
-  (∀v. v_lookup [] (v : (α,β) v) =
+  (∀v. v_lookup [] v =
     (v_to_prefix v, case v of Constructor c vs => LENGTH vs | _ => 0)) ∧
-  ∀n path. v_lookup (n::path) (v : (α,β) v) =
+  ∀n path. v_lookup (n::path) v =
     (case v of
     | Constructor c vs =>
       (case oEL n vs of
@@ -531,7 +517,7 @@ Theorem v_lookup_alt:
       | NONE => (Diverge', 0))
     | _ => (Diverge', 0))
 Proof
-  assume_tac (v_rep_ok_Atom |> swap_alpha_beta) >>
+  assume_tac v_rep_ok_Atom >>
   assume_tac v_rep_ok_Constructor >>
   assume_tac v_rep_ok_Closure >>
   assume_tac v_rep_ok_Diverge >>
@@ -548,14 +534,14 @@ Proof
 QED
 
 Theorem v_lookup:
-  (∀v. v_lookup [] (v : (α,β) v) =
+  (∀v. v_lookup [] v =
     case v of
     | Atom a => (Atom' a, 0)
     | Constructor c vs => (Constructor' c, LENGTH vs)
     | Closure x body => (Closure' x body, 0)
     | Diverge => (Diverge', 0)
     | Error => (Error', 0)) ∧
-  ∀n path. v_lookup (n::path) (v : (α,β) v) =
+  ∀n path. v_lookup (n::path) v =
     (case v of
     | Constructor c vs =>
       (case oEL n vs of
@@ -630,7 +616,7 @@ Proof
   qexists_tac `len_opt` >> fs[]
 QED
 
-(* gen_v : (num list -> (α,β) vprefix # num) -> (α,β) v *)
+(* gen_v : (num list -> vprefix # num) -> v *)
 (* Generates a value of type v given a function generating v_prefix nodes when
    given a path *)
 Definition gen_v_def:
@@ -652,7 +638,7 @@ Proof
   fs[v_repabs] >>
   simp[make_v_rep_def, Once gen_ltree] >>
   Cases_on `f []` >> rename1 `f [] = (prefix, len)` >> fs[] >>
-  assume_tac (v_rep_ok_Atom |> swap_alpha_beta) >>
+  assume_tac v_rep_ok_Atom >>
   assume_tac v_rep_ok_Constructor >>
   assume_tac v_rep_ok_Closure >>
   assume_tac v_rep_ok_Diverge >>


### PR DESCRIPTION
This PR introduces abstract types for literals (`:lit`) and atomic operations (`:atom_op`), and an abstract configuration using these types. Nothing is assumed about the config, nor `:lit` and `:atom_op`.

As a consequence, `eval` and `v_rel` no longer take a configuration as argument (the semantics instead refers to the abstract config), and the types `:('a, 'b) exp`, `:('a, 'b) v` also loose their type variables and becomes `:exp`, `:v`.

