### PR TITLE
Change the semantics of AtomOp in pureLang and thunkLang/envLang

### DIFF
--- a/compiler/backend/envLangScript.sml
+++ b/compiler/backend/envLangScript.sml
@@ -11,7 +11,7 @@
 
 open HolKernel Parse boolLib bossLib term_tactic monadsyntax;
 open stringTheory optionTheory sumTheory pairTheory listTheory alistTheory
-     pure_expTheory thunkLang_primitivesTheory;
+     pure_expTheory thunkLang_primitivesTheory pure_miscTheory;
 
 val _ = new_theory "envLang";
 
@@ -294,13 +294,16 @@ Proof
       last_x_assum mp_tac
       \\ gs [result_map_def, MEM_MAP]
       \\ IF_CASES_TAC \\ gs []
-      \\ gs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
+      >- (
+        first_x_assum (drule_then (drule_at_then Any assume_tac))
+        \\ rw [] \\ gs [])
+      \\ fs [DECIDE “A ⇒ ¬MEM a b ⇔ MEM a b ⇒ ¬A”]
+      \\ IF_CASES_TAC \\ gs []
       \\ IF_CASES_TAC \\ gs []
       >- (
-        IF_CASES_TAC \\ gs []
-        \\ IF_CASES_TAC  \\ gs []
-        \\ gs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)])
-      \\ IF_CASES_TAC \\ gs []
+        first_x_assum (drule_then (drule_at_then Any assume_tac))
+        \\ rw [] \\ gs [])
+      \\ fs [DECIDE “A ⇒ ¬MEM a b ⇔ MEM a b ⇒ ¬A”]
       \\ IF_CASES_TAC \\ gs []
       \\ rw [MAP_MAP_o, combinTheory.o_DEF, MAP_EQ_f])
     >- ((* IsEq *)
@@ -317,54 +320,50 @@ Proof
       qmatch_goalsub_abbrev_tac ‘result_map f xs’
       \\ qmatch_asmsub_abbrev_tac ‘result_map g xs’
       \\ last_x_assum mp_tac
+      \\ Cases_on ‘k = 0’ \\ gs []
+      >- (
+        gs [result_map_def, MEM_MAP]
+        \\ Cases_on ‘xs = []’ \\ gs []
+        \\ gs [pure_miscTheory.NIL_iff_NOT_MEM, Abbr ‘f’, Abbr ‘g’]
+        \\ rw [] \\ gs [])
       \\ gs [result_map_def, MEM_MAP]
       \\ IF_CASES_TAC \\ gs []
-      \\ gs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
+      >- (
+        rw [] \\ gs [Abbr ‘f’, Abbr ‘g’]
+        \\ pop_assum kall_tac
+        \\ ‘eval_to (k - 1) env y ≠ INL Diverge’
+          by (strip_tac \\ gs [])
+        \\ first_x_assum (qspec_then ‘y’ assume_tac)
+        \\ gs [])
+      \\ fs [DECIDE “A ⇒ ¬MEM a b ⇔ MEM a b ⇒ ¬A”]
+      \\ IF_CASES_TAC \\ gs []
       \\ IF_CASES_TAC \\ gs []
       >- (
-        IF_CASES_TAC \\ gs []
-        >- (
-          rename1 ‘MEM x xs’
-          \\ unabbrev_all_tac
-          \\ ‘eval_to (j - 1) env x = INL Diverge’
-            by gs [CaseEqs ["sum", "v"]]
-          \\ gs [CaseEq "bool"]
-          \\ first_x_assum (drule_then assume_tac)
-          \\ gs [CaseEqs ["sum", "v"]])
+        rw [] \\ gs [Abbr ‘f’, Abbr ‘g’]
+        \\ ‘eval_to (k - 1) env y ≠ INL Diverge’
+          by (strip_tac \\ gs [])
+        \\ first_x_assum (qspec_then ‘y’ assume_tac) \\ gs [])
+      \\ fs [DECIDE “A ⇒ ¬MEM a b ⇔ MEM a b ⇒ ¬A”]
       \\ IF_CASES_TAC \\ gs []
-      \\ ‘F’ suffices_by rw []
-      \\ fs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
-      \\ unabbrev_all_tac
-      \\ first_x_assum (drule_then assume_tac) \\ gs []
-      \\ gs [CaseEqs ["sum", "v", "bool"]])
-    \\ IF_CASES_TAC \\ gs []
-    >- (
-      ‘F’ suffices_by rw []
-      \\ gs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
-      \\ rpt (first_x_assum (drule_then assume_tac))
-      \\ unabbrev_all_tac \\ gs []
-      \\ gs [CaseEqs ["sum", "v", "bool"]])
-    \\ IF_CASES_TAC \\ gs []
-    >- (
-      ‘F’ suffices_by rw []
-      \\ gs [Once (METIS_PROVE [] “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
-      \\ rpt (first_x_assum (drule_then assume_tac))
-      \\ unabbrev_all_tac \\ gs []
-      \\ gs [CaseEqs ["sum", "v", "bool"]])
-    \\ gs [MAP_MAP_o, combinTheory.o_DEF]
-    \\ strip_tac
-    \\ ‘MAP (OUTR o f) xs = MAP (OUTR o g) xs’
-      suffices_by rw [combinTheory.o_DEF]
-    \\ rw [MAP_EQ_f]
-    \\ ntac 4 (first_x_assum (qspec_then ‘e’ assume_tac))
-    \\ Cases_on ‘∃err. f e = INL err’ \\ gs []
-    >- (
-      Cases_on ‘err’ \\ gs [])
-    \\ Cases_on ‘∃err. g e = INL err’ \\ gs []
-    >- (
-      Cases_on ‘err’ \\ gs [])
-    \\ Cases_on ‘f e’ \\ Cases_on ‘g e’ \\ gs [Abbr ‘f’, Abbr ‘g’]
-    \\ gs [CaseEqs ["bool", "sum"]]))
+      >- (
+        first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ gs [Abbr ‘f’, Abbr ‘g’]
+        \\ first_x_assum (drule_then (qspec_then ‘j - 1’ assume_tac)) \\ gs []
+        \\ Cases_on ‘eval_to (k - 1) env y’ \\ gs [])
+      \\ fs [DECIDE “A ⇒ ¬MEM a b ⇔ MEM a b ⇒ ¬A”]
+      \\ ‘MAP (OUTR o f) xs = MAP (OUTR o g) xs’
+        suffices_by rw [combinTheory.o_DEF, MAP_MAP_o]
+      \\ rw [MAP_EQ_f]
+      \\ ntac 4 (first_x_assum (qspec_then ‘e’ assume_tac))
+      \\ Cases_on ‘f e’ \\ gs []
+      >- (
+        rename1 ‘err ≠ Type_error’ \\ Cases_on ‘err’ \\ gs [])
+      \\ Cases_on ‘g e’ \\ gs []
+      >- (
+        rename1 ‘err ≠ Type_error’ \\ Cases_on ‘err’ \\ gs [])
+      \\ gs [Abbr ‘f’, Abbr ‘g’, CaseEq "sum"]))
 QED
 
 val _ = export_theory ();

--- a/compiler/backend/proofs/pure_letrecProofScript.sml
+++ b/compiler/backend/proofs/pure_letrecProofScript.sml
@@ -887,87 +887,52 @@ Proof
       csimp[EL_MAP] >> gvs[EL_MAP] >>
       last_x_assum kall_tac
       \\ last_x_assum kall_tac
-      \\ map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`n < _`, `eval_wh_to _ _ = _`, `∀m. m < _ ⇒ _`, `EVERY _ _`,
-         `EVERY _ _`, `LENGTH _ = _`]
-      \\ last_x_assum mp_tac >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
+      \\ gvs [EVERY_MAP, MEM_MAP, EVERY_MEM, MEM_EL, PULL_EXISTS]
+      \\ simp [RIGHT_EXISTS_AND_THM]
+      \\ strip_tac
       >- (
-        qexists_tac `0` >> gvs[] >>
-        first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> rw[] >>
-        CCONTR_TAC >> drule eval_wh_inc >>
-        disch_then (qspec_then `ck + k - 1` mp_tac) >> simp[]
-        ) >>
-      rename1 `n < _` >>
-      Cases_on `eval_wh_to (k - 1) h2 = wh_Diverge`
-      >- (qexists_tac `0` >> simp[]) >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[IMP_CONJ_THM] >>
-      impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >> rename1 `l < _` >>
-      qexists_tac `SUC l` >> simp[] >> rw[] >>
-      Cases_on `m` >> gvs[] >>
-      last_x_assum (qspec_then `0` assume_tac) >> gvs[] >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >> gs [] >>
-      drule eval_wh_to_agree >>
-      disch_then (qspec_then `ck + k - 1` mp_tac) >> simp [] >>
-      disch_then (assume_tac o SYM) \\ fs []) >>
+        qx_gen_tac ‘m’
+        \\ strip_tac
+        \\ gvs [LIST_REL_EL_EQN]
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+        \\ strip_tac
+        \\ ‘eval_wh_to (k - 1) (EL m ys) ≠ wh_Diverge’
+          by (strip_tac \\ gs [])
+        \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+        \\ Cases_on ‘eval_wh_to (k - 1) (EL m xs)’ \\ gs [])
+      \\ gvs [LIST_REL_EL_EQN]
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ gs []
+      \\ first_x_assum (irule_at Any)
+      \\ CCONTR_TAC
+      \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+    ) >>
     Cases_on `x` >> gvs[]
     >- (
       gvs[get_atoms_SOME_NONE_eq, EL_MAP] >>
       qsuff_tac
         `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME NONE`
       >- (rw[] >> qexists_tac `ck` >> simp[]) >>
-      simp[get_atoms_SOME_NONE_eq] >> csimp[EL_MAP] >>
-      imp_res_tac LIST_REL_LENGTH >> gvs[] >> goal_assum drule >>
-      map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`∀e1 x. MEM e1 _ ⇒ _`, `n < _`,` ∀a. eval_wh_to _ _ ≠ _`,
-         `∀m. m ≤ _ ⇒ _`, `EVERY _ _`, `EVERY _ _`, `LENGTH _ = _`] >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
-      >- (
-        pop_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> strip_tac >>
-        qexists_tac `ck` >>
-        Cases_on `eval_wh_to (k - 1) h1` >> gvs[]
-        ) >>
-      rename1 `SUC n` >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[] >> impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >>
-      qexists_tac `ck + ck'` >> rw[]
-      >- (
-        qpat_x_assum `∀a. _ ≠ wh_Atom a` (qspec_then `a` mp_tac) >>
-        first_x_assum (qspec_then `n` mp_tac) >> simp[] >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        ) >>
-      Cases_on `m` >> gvs[]
-      >- (
-        qspecl_then [`ck + (ck' + k) - 1`,`h2`,`ck' + k - 1`]
-          assume_tac eval_wh_inc >>
-        gvs[] >>
-        full_case_tac >> gvs[] >>
-        last_x_assum (qspec_then `0` assume_tac) >> gvs[]
-        )
-      >- (
-        rename1 `m ≤ _` >>
-        first_x_assum drule >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        )
-      ) >>
+      simp[get_atoms_SOME_NONE_eq]
+      \\ gvs [EXISTS_MAP, EXISTS_MEM, EVERY_MEM, LIST_REL_EL_EQN, MEM_EL,
+              PULL_EXISTS]
+      \\ first_assum (irule_at Any)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ qexists_tac ‘ck’
+      \\ Cases_on ‘eval_wh_to (k - 1) (EL n xs)’ \\ gs []
+    ) >>
     rename1 `SOME (SOME as)` >>
     qsuff_tac
       `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME (SOME as)`
@@ -977,9 +942,9 @@ Proof
       CASE_TAC >> gvs[]
       \\ CASE_TAC >> gvs[]
       \\ IF_CASES_TAC \\ fs []) >>
-    gvs[get_atoms_SOME_SOME_eq, EVERY2_MAP] >>
-    map_every (fn pat => qpat_x_assum pat mp_tac)
-      [`∀e1 x. MEM e1 _ ⇒ _`, `LIST_REL _ _ _`, `EVERY _ _`, `EVERY _ _`] >>
+    gvs [get_atoms_SOME_SOME_eq, EVERY2_MAP, MEM_EL, PULL_EXISTS]
+    \\ map_every (fn pat => qpat_x_assum pat mp_tac)
+      [`∀e1 n. n < _ ⇒ _`, `LIST_REL _ _ _`, `EVERY _ _`, `EVERY _ _`] >>
     qid_spec_tac `as` >>
     qpat_x_assum `LIST_REL _ _ _` mp_tac >>
     map_every qid_spec_tac [`ys`,`xs`] >>
@@ -990,6 +955,7 @@ Proof
     >- (
       disch_then (qx_choose_then ‘ck'’ mp_tac) >>
       pop_assum (qspec_then `h1` mp_tac) >> simp[] >>
+      disch_then (qspec_then ‘0’ mp_tac) >> simp [] >>
       disch_then drule_all >> rw[] >>
       qexists_tac `ck + ck'` >>
       qspecl_then [`ck + ck' + k - 1`,`h2`,`ck + k - 1`]
@@ -999,7 +965,9 @@ Proof
         assume_tac eval_wh_inc >>
       gvs[]
       ) >>
-    last_x_assum irule >> simp[]
+    last_x_assum irule >> simp[] \\ rw []
+    \\ first_x_assum (irule_at Any) \\ gs []
+    \\ qexists_tac ‘n’ \\ gs []
     )
   >- (
     imp_res_tac LIST_REL_LENGTH >>

--- a/compiler/backend/proofs/pure_letrec_funProofScript.sml
+++ b/compiler/backend/proofs/pure_letrec_funProofScript.sml
@@ -408,7 +408,6 @@ Proof
     ) >>
   Cases_on `p` >> gvs[eval_wh_to_def]
   >- (
-    (*IF_CASES_TAC >> gvs[] >- (qexists_tac `0` >> gvs[]) >>*)
     IF_CASES_TAC >> gvs[LIST_REL_EL_EQN] >>
     `∃x1 x2 x3. xs = [x1;x2;x3]` by fs[LENGTH_EQ_NUM_compute] >>
     `∃y1 y2 y3. ys = [y1;y2;y3]` by fs[LENGTH_EQ_NUM_compute] >>
@@ -520,6 +519,7 @@ Proof
     qexists_tac `ck + ck'` >> gvs[]
     )
   >- (
+    cheat (* TODO: This previously worked (and probably still does) *) (*
     CASE_TAC >> gvs[]
     >- (
       qsuff_tac `get_atoms (MAP (λa. eval_wh_to (k − 1) a) ys) = NONE`
@@ -639,7 +639,7 @@ Proof
         assume_tac eval_wh_inc
       \\ gvs[]
       ) >>
-    last_x_assum irule >> simp[]
+    last_x_assum irule >> simp[] *)
     )
   >- (
     imp_res_tac LIST_REL_LENGTH >>

--- a/compiler/backend/proofs/pure_letrec_funProofScript.sml
+++ b/compiler/backend/proofs/pure_letrec_funProofScript.sml
@@ -519,95 +519,55 @@ Proof
     qexists_tac `ck + ck'` >> gvs[]
     )
   >- (
-    cheat (* TODO: This previously worked (and probably still does) *) (*
     CASE_TAC >> gvs[]
     >- (
       qsuff_tac `get_atoms (MAP (λa. eval_wh_to (k − 1) a) ys) = NONE`
       >- (rw[] >> qexists_tac `0` >> simp[]) >>
-      gvs[get_atoms_NONE_eq] >> imp_res_tac LIST_REL_LENGTH >> gvs[] >>
-      csimp[EL_MAP] >> gvs[EL_MAP] >>
-      map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`∀e1 e2. MEM e1 _ ⇒ _`, `n < _`,`eval_wh_to _ _ = _`, `∀m. m < _ ⇒ _`,
-         `EVERY _ _`, `EVERY _ _`, `LENGTH _ = _`] >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
+      gs [get_atoms_NONE_eq]
+      \\ gvs [MEM_MAP, EVERY_MAP, EVERY_MEM, MEM_EL, PULL_EXISTS,
+              LIST_REL_EL_EQN]
+      \\ simp [RIGHT_EXISTS_AND_THM]
+      \\ conj_tac
       >- (
-        qexists_tac `0` >> gvs[] >>
-        first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> rw[] >>
-        CCONTR_TAC >> drule eval_wh_inc >>
-        disch_then (qspec_then `ck + k - 1` mp_tac) >> simp[]
-        ) >>
-      rename1 `n < _` >>
-      Cases_on `eval_wh_to (k - 1) h2 = wh_Diverge`
-      >- (qexists_tac `0` >> simp[]) >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[IMP_CONJ_THM] >>
-      impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >> rename1 `l < _` >>
-      qexists_tac `SUC l` >> simp[] >> rw[] >>
-      Cases_on `m` >> gvs[] >>
-      last_x_assum (qspec_then `0` assume_tac) >> gvs[] >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >>
-      drule eval_wh_to_agree >>
-      disch_then (qspec_then `ck + k - 1` mp_tac) >> rw[] >>
-      Cases_on ‘eval_wh_to (k - 1) h1’ \\ gvs []
-      \\ metis_tac[]
-      ) >>
+        qx_gen_tac ‘m’
+        \\ strip_tac
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+        \\ strip_tac
+        \\ ‘eval_wh_to (k - 1) (EL m ys) ≠ wh_Diverge’
+          by (strip_tac \\ gs [])
+        \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+        \\ Cases_on ‘eval_wh_to (k - 1) (EL m xs)’ \\ gs [])
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ first_assum (irule_at Any)
+      \\ CCONTR_TAC
+      \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+    ) >>
     Cases_on `x` >> gvs[]
     >- (
       gvs[get_atoms_SOME_NONE_eq, EL_MAP] >>
       qsuff_tac
         `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME NONE`
       >- (rw[] >> qexists_tac `ck` >> simp[]) >>
-      simp[get_atoms_SOME_NONE_eq] >> csimp[EL_MAP] >>
-      imp_res_tac LIST_REL_LENGTH >> gvs[] >> goal_assum drule >>
-      map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`∀e1 e2. MEM e1 _ ⇒ _`, `n < _`,` ∀a. eval_wh_to _ _ ≠ _`,
-         `∀m. m ≤ _ ⇒ _`, `EVERY _ _`, `EVERY _ _`, `LENGTH _ = _`] >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
-      >- (
-        pop_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> strip_tac >>
-        qexists_tac `ck` >>
-        Cases_on `eval_wh_to (k - 1) h1` >> gvs[]
-        ) >>
-      rename1 `SUC n` >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[] >> impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >>
-      qexists_tac `ck + ck'` >> rw[]
-      >- (
-        qpat_x_assum `∀a. _ ≠ wh_Atom a` (qspec_then `a` mp_tac) >>
-        first_x_assum (qspec_then `n` mp_tac) >> simp[] >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        ) >>
-      Cases_on `m` >> gvs[]
-      >- (
-        qspecl_then [`ck + (ck' + k) - 1`,`h2`,`ck' + k - 1`]
-          assume_tac eval_wh_inc >>
-        gvs[] >>
-        full_case_tac >> gvs[] >>
-        last_x_assum (qspec_then `0` assume_tac) >> gvs[]
-        )
-      >- (
-        rename1 `m ≤ _` >>
-        first_x_assum drule >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        )
-      ) >>
+      simp[get_atoms_SOME_NONE_eq] >> csimp[] >>
+      gvs [EVERY_MEM, EXISTS_MAP, EXISTS_MEM, MEM_EL, PULL_EXISTS,
+           LIST_REL_EL_EQN]
+      \\ first_assum (irule_at Any)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ qexists_tac ‘ck’
+      \\ Cases_on ‘eval_wh_to (k - 1) (EL n xs)’ \\ gs []
+    ) >>
     rename1 `SOME (SOME as)` >>
     qsuff_tac
       `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME (SOME as)`
@@ -617,9 +577,9 @@ Proof
       \\ CASE_TAC \\ gvs[]
       \\ CASE_TAC \\ gvs[]
       \\ CASE_TAC \\ gvs[]) >>
-    gvs[get_atoms_SOME_SOME_eq, EVERY2_MAP] >>
-    map_every (fn pat => qpat_x_assum pat mp_tac)
-      [`∀e1 es. MEM e1 _ ⇒ _`, `LIST_REL _ _ _`, `EVERY _ _`, `EVERY _ _`] >>
+    gvs [get_atoms_SOME_SOME_eq, EVERY2_MAP, MEM_EL, PULL_EXISTS]
+    \\ map_every (fn pat => qpat_x_assum pat mp_tac)
+      [`∀e1 n. n < _ ⇒ _`, `LIST_REL _ _ _`, `EVERY _ _`, `EVERY _ _`] >>
     qid_spec_tac `as` >>
     qpat_x_assum `LIST_REL _ _ _` mp_tac >>
     map_every qid_spec_tac [`ys`,`xs`] >>
@@ -630,6 +590,7 @@ Proof
     >- (
       disch_then (qx_choose_then ‘ck’ mp_tac)
       \\ pop_assum (qspec_then `h1` mp_tac) \\ simp[]
+      \\ disch_then (qspec_then ‘0’ mp_tac) \\ simp []
       \\ disch_then drule_all \\ rw[]
       \\ qexists_tac `ck + ck'`
       \\ qspecl_then [`ck + ck' + k - 1`,`h2`,`ck' + k - 1`]
@@ -639,7 +600,9 @@ Proof
         assume_tac eval_wh_inc
       \\ gvs[]
       ) >>
-    last_x_assum irule >> simp[] *)
+    last_x_assum irule >> simp[] \\ rw []
+    \\ first_x_assum irule \\ gs []
+    \\ qexists_tac ‘n’ \\ gs []
     )
   >- (
     imp_res_tac LIST_REL_LENGTH >>

--- a/compiler/backend/proofs/pure_letrec_lamProofScript.sml
+++ b/compiler/backend/proofs/pure_letrec_lamProofScript.sml
@@ -597,90 +597,50 @@ Proof
     >- (
       qsuff_tac `get_atoms (MAP (λa. eval_wh_to (k − 1) a) ys) = NONE`
       >- (rw[] >> qexists_tac `0` >> simp[]) >>
-      gvs[get_atoms_NONE_eq] >> imp_res_tac LIST_REL_LENGTH >> gvs[] >>
-      csimp[EL_MAP] >> gvs[EL_MAP] >>
-      map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`∀e1 e2. MEM e1 _ ⇒ _`, `n < _`,`eval_wh_to _ _ = _`, `∀m. m < _ ⇒ _`,
-         `EVERY _ _`, `EVERY _ _`, `LENGTH _ = _`] >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
+      gvs[get_atoms_NONE_eq]
+      \\ gs [EVERY_MAP, MEM_MAP, EVERY_MEM, MEM_EL, PULL_EXISTS,
+             LIST_REL_EL_EQN]
+      \\ simp [RIGHT_EXISTS_AND_THM]
+      \\ strip_tac
       >- (
-        qexists_tac `0` >> gvs[] >>
-        first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> rw[] >>
-        CCONTR_TAC >> drule eval_wh_inc >>
-        disch_then (qspec_then `ck + k - 1` mp_tac) >> simp[]
-        ) >>
-      rename1 `n < _` >>
-      Cases_on `eval_wh_to (k - 1) h2 = wh_Diverge`
-      >- (qexists_tac `0` >> simp[]) >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[IMP_CONJ_THM] >>
-      impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >> rename1 `l < _` >>
-      qexists_tac `SUC l` >> simp[] >> rw[] >>
-      Cases_on `m` >> gvs[] >>
-      last_x_assum (qspec_then `0` assume_tac) >> gvs[] >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >>
-      drule eval_wh_to_agree >>
-      disch_then (qspec_then `ck + k - 1` mp_tac) >> rw[] >>
-      Cases_on ‘eval_wh_to (k - 1) h1’ \\ gvs []
-      \\ metis_tac[]
-      ) >>
+        qx_gen_tac ‘m’ \\ strip_tac
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_then assume_tac)
+        \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+        \\ strip_tac
+        \\ ‘eval_wh_to (k - 1) (EL m ys) ≠ wh_Diverge’
+          by (strip_tac \\ gs [])
+        \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+        \\ Cases_on ‘eval_wh_to (k - 1) (EL m xs)’ \\ gs [])
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ first_assum (irule_at Any)
+      \\ CCONTR_TAC
+      \\ drule_then (qspec_then ‘ck + k - 1’ assume_tac) eval_wh_inc \\ gs []
+    ) >>
     Cases_on `x` >> gvs[]
     >- (
       gvs[get_atoms_SOME_NONE_eq, EL_MAP] >>
       qsuff_tac
         `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME NONE`
       >- (rw[] >> qexists_tac `ck` >> simp[]) >>
-      simp[get_atoms_SOME_NONE_eq] >> csimp[EL_MAP] >>
-      imp_res_tac LIST_REL_LENGTH >> gvs[] >> goal_assum drule >>
-      map_every (fn pat => qpat_x_assum pat mp_tac)
-        [`∀e1 e2. MEM e1 _ ⇒ _`, `n < _`,` ∀a. eval_wh_to _ _ ≠ _`,
-         `∀m. m ≤ _ ⇒ _`, `EVERY _ _`, `EVERY _ _`, `LENGTH _ = _`] >>
-      qid_spec_tac `n` >>
-      qpat_x_assum `LIST_REL _ _ _` mp_tac >>
-      map_every qid_spec_tac [`ys`,`xs`] >>
-      ho_match_mp_tac LIST_REL_ind >> rw[] >>
-      Cases_on `n` >> gvs[]
-      >- (
-        pop_assum (qspec_then `h1` mp_tac) >> simp[] >>
-        disch_then drule_all >> strip_tac >>
-        qexists_tac `ck` >>
-        Cases_on `eval_wh_to (k - 1) h1` >> gvs[]
-        ) >>
-      rename1 `SUC n` >>
-      last_x_assum (qspec_then `n` mp_tac) >> simp[] >> impl_tac
-      >- (rw[] >> last_x_assum (qspec_then `SUC m` mp_tac) >> simp[]) >>
-      strip_tac >>
-      first_x_assum (qspec_then `h1` mp_tac) >> simp[] >>
-      disch_then drule_all >> strip_tac >>
-      qexists_tac `ck + ck'` >> rw[]
-      >- (
-        qpat_x_assum `∀a. _ ≠ wh_Atom a` (qspec_then `a` mp_tac) >>
-        first_x_assum (qspec_then `n` mp_tac) >> simp[] >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        ) >>
-      Cases_on `m` >> gvs[]
-      >- (
-        qspecl_then [`ck + (ck' + k) - 1`,`h2`,`ck' + k - 1`]
-          assume_tac eval_wh_inc >>
-        gvs[] >>
-        full_case_tac >> gvs[] >>
-        last_x_assum (qspec_then `0` assume_tac) >> gvs[]
-        )
-      >- (
-        rename1 `m ≤ _` >>
-        first_x_assum drule >> strip_tac >>
-        drule eval_wh_inc >>
-        disch_then (qspec_then `ck + (ck' + k) - 1` assume_tac) >> gvs[]
-        )
-      ) >>
+      simp[get_atoms_SOME_NONE_eq]
+      \\ gvs [EXISTS_MAP, EVERY_MEM, EXISTS_MEM, MEM_EL, PULL_EXISTS,
+              LIST_REL_EL_EQN]
+      \\ first_assum (irule_at Any)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_then assume_tac)
+      \\ first_x_assum (drule_all_then (qx_choose_then ‘ck’ assume_tac))
+      \\ qexists_tac ‘ck’
+      \\ Cases_on ‘eval_wh_to (k - 1) (EL n xs)’ \\ gs []
+    ) >>
     rename1 `SOME (SOME as)` >>
     qsuff_tac
       `∃ck. get_atoms (MAP (λa. eval_wh_to (ck + k − 1) a) ys) = SOME (SOME as)`
@@ -690,10 +650,10 @@ Proof
       \\ CASE_TAC \\ gvs[]
       \\ CASE_TAC \\ gvs[]
       \\ CASE_TAC \\ gvs[]) >>
-    gvs[get_atoms_SOME_SOME_eq, EVERY2_MAP] >>
-    map_every (fn pat => qpat_x_assum pat mp_tac)
-      [`∀e1 es. MEM e1 _ ⇒ _`, `LIST_REL _ _ _`, `EVERY _ _`, `EVERY _ _`] >>
-    qid_spec_tac `as` >>
+    gvs [get_atoms_SOME_SOME_eq, EVERY2_MAP, EVERY_MEM, MEM_EL, PULL_EXISTS]
+    \\ map_every (fn pat => qpat_x_assum pat mp_tac)
+      [`∀e1 n. n < _ ⇒ _`, `LIST_REL _ _ _`, `∀n. n < _ ⇒ _`, `∀n. n < _ ⇒ _`]
+    \\ qid_spec_tac `as` >>
     qpat_x_assum `LIST_REL _ _ _` mp_tac >>
     map_every qid_spec_tac [`ys`,`xs`] >>
     ho_match_mp_tac LIST_REL_strongind >> rw[] >>
@@ -703,6 +663,9 @@ Proof
     >- (
       disch_then (qx_choose_then ‘ck’ mp_tac)
       \\ pop_assum (qspec_then `h1` mp_tac) \\ simp[]
+      \\ first_x_assum (qspec_then ‘0’ assume_tac)
+      \\ first_x_assum (qspec_then ‘0’ assume_tac) \\ gs []
+      \\ disch_then (qspec_then ‘0’ mp_tac) \\ simp []
       \\ disch_then drule_all \\ rw[]
       \\ qexists_tac `ck + ck'`
       \\ qspecl_then [`ck + ck' + k - 1`,`h2`,`ck' + k - 1`]
@@ -713,6 +676,14 @@ Proof
       \\ gvs[]
       ) >>
     last_x_assum irule >> simp[]
+    \\ rw [] \\ gs []
+    >- (
+      first_x_assum irule \\ gs []
+      \\ qexists_tac ‘n’
+      \\ gs [])
+    \\ gvs [LIST_REL_EL_EQN]
+    \\ ‘SUC n < SUC (LENGTH ys)’ by gs []
+    \\ rpt (first_x_assum (drule_then assume_tac)) \\ gs []
     )
   >- (
     imp_res_tac LIST_REL_LENGTH >> gvs[] >>
@@ -723,7 +694,6 @@ Proof
     first_assum (drule_all_then strip_assume_tac) >>
     qpat_x_assum ‘letrec_rel c x2 _’ assume_tac >>
     first_x_assum (drule_all_then strip_assume_tac) >>
-
     Cases_on `eval_wh_to (k - 1) x1 = wh_Diverge` >> gvs[]
     >- (qexists_tac `ck` >> gvs[]) >>
     IF_CASES_TAC >> gvs[]

--- a/compiler/backend/proofs/pure_to_thunkProofScript.sml
+++ b/compiler/backend/proofs/pure_to_thunkProofScript.sml
@@ -731,9 +731,8 @@ Proof
         \\ IF_CASES_TAC \\ fs [])
       \\ ‘ys ≠ []’ by (strip_tac \\ fs [])
       \\ simp [get_atoms_MAP_Diverge]
-      \\ ‘∃x. MEM x ys’
-        by (qexists_tac ‘HD ys’ \\ Cases_on ‘xs’ \\ Cases_on ‘ys’ \\ gs [])
-      \\ simp [SF SFY_ss])
+      \\ gs [NIL_iff_NOT_MEM]
+      \\ rw [] \\ gs [])
     \\ rw [Once exp_rel_cases]
     >- ((* If *)
       simp [eval_to_def, eval_wh_to_def]
@@ -819,14 +818,34 @@ Proof
         \\ gs [MEM_EL, PULL_EXISTS, EVERY_EL, eval_wh_to_def]
         \\ CASE_TAC \\ fs []
         >- (
-          gvs [get_atoms_NONE_eq, EL_MAP]
+          gvs [get_atoms_NONE_eq, EVERY_MAP, MEM_MAP, EVERY_MEM, MEM_EL,
+               PULL_EXISTS]
           \\ ‘result_map f ys = INL Diverge’
             suffices_by rw []
           \\ gvs [result_map_def, MEM_MAP, MEM_EL, PULL_EXISTS, CaseEq "bool"]
-          \\ unabbrev_all_tac
-          \\ first_assum (irule_at Any) \\ gs []
-          \\ ‘eval_wh_to (k - 1) (EL n xs) ≠ wh_Error’ by gs []
-          \\ rpt (first_x_assum (drule_all_then assume_tac))
+          \\ simp [RIGHT_EXISTS_AND_THM]
+          \\ reverse conj_tac
+          >- (
+            first_assum (irule_at Any)
+            \\ first_x_assum (drule_then assume_tac)
+            \\ ‘eval_wh_to (k - 1) (EL n xs) ≠ wh_Error’
+              by (strip_tac \\ gs [])
+            \\ first_x_assum (drule_all_then assume_tac)
+            \\ first_x_assum (drule_all_then assume_tac)
+            \\ first_x_assum (drule_all_then assume_tac)
+            \\ unabbrev_all_tac \\ gs []
+            \\ CASE_TAC \\ gs [])
+          \\ qx_gen_tac ‘m’
+          \\ rw [DECIDE “A ⇒ ¬B ⇔ B ⇒ ¬A”]
+          \\ first_x_assum (drule_then assume_tac)
+          \\ ‘eval_wh_to (k - 1) (EL m xs) ≠ wh_Error’
+            by (strip_tac \\ gs [])
+          \\ first_x_assum (drule_all_then assume_tac)
+          \\ first_x_assum (drule_all_then assume_tac)
+          \\ first_x_assum (drule_all_then assume_tac)
+          \\ unabbrev_all_tac \\ gs []
+          \\ CASE_TAC \\ gs []
+          \\ Cases_on ‘eval_wh_to (k - 1) (EL m xs)’ \\ gs []
           \\ CASE_TAC \\ gs [])
         \\ CASE_TAC \\ gs []
         \\ gvs [get_atoms_SOME_SOME_eq, EVERY2_MAP]

--- a/compiler/backend/proofs/thunk_to_envProofScript.sml
+++ b/compiler/backend/proofs/thunk_to_envProofScript.sml
@@ -972,7 +972,8 @@ Proof
         \\ first_x_assum (drule_then assume_tac)
         \\ unabbrev_all_tac \\ gs []
         \\ rpt (first_x_assum (drule_then assume_tac))
-        \\ gs [CaseEqs ["sum", "v"]])
+        \\ gvs [CaseEqs ["sum", "v"]]
+        \\ rename1 ‘v_rel _ w’ \\ Cases_on ‘w’ \\ gs [v_rel_def])
       \\ IF_CASES_TAC \\ gs []
       >- (
         reverse IF_CASES_TAC \\ gs []
@@ -990,7 +991,13 @@ Proof
         \\ rpt (first_x_assum (drule_then assume_tac))
         \\ pop_assum mp_tac
         \\ rpt CASE_TAC \\ gs []
-        \\ rpt strip_tac \\ gs [CaseEqs ["sum", "envLang$v"]])
+        >- (
+          strip_tac \\ gs [CaseEqs ["sum", "envLang$v"]])
+        \\ rw [DISJ_EQ_IMP]
+        \\ strip_tac
+        \\ last_x_assum (qspec_then ‘EL n xs’ assume_tac)
+        \\ gs [CaseEqs ["sum", "envLang$v", "v"]]
+        \\ Cases_on ‘y’ \\ gvs [v_rel_def])
       \\ IF_CASES_TAC \\ gs []
       >- (
         fs [Once (DECIDE “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
@@ -999,7 +1006,12 @@ Proof
         \\ rpt (first_x_assum (drule_then assume_tac))
         \\ pop_assum mp_tac
         \\ rpt CASE_TAC \\ gs []
-        \\ rpt strip_tac \\ gs [CaseEqs ["sum", "envLang$v"]])
+        >- (
+          strip_tac \\ gs [CaseEqs ["sum", "envLang$v"]])
+        \\ rw [DISJ_EQ_IMP]
+        \\ strip_tac
+        \\ gs [CaseEqs ["sum", "envLang$v", "v"]]
+        \\ Cases_on ‘y’ \\ gvs [v_rel_def])
       \\ fs [Once (DECIDE “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
       \\ gs [EL_MAP, MEM_EL, PULL_EXISTS]
       \\ unabbrev_all_tac \\ gs [] \\ rw []

--- a/compiler/backend/proofs/thunk_unthunkProofScript.sml
+++ b/compiler/backend/proofs/thunk_unthunkProofScript.sml
@@ -797,14 +797,18 @@ Proof
           \\ rename1 ‘m < LENGTH ys’
           \\ rpt (first_x_assum (drule_then assume_tac))
           \\ Cases_on ‘eval_to (k - 1) (EL m ys)’
-          \\ gvs [CaseEqs ["sum", "v"]])
+          \\ gvs [CaseEqs ["sum", "v"]]
+          \\ rename1 ‘v_rel _ w’
+          \\ Cases_on ‘w’ \\ gs [])
         \\ gvs [result_map_def, CaseEq "bool", Abbr ‘f’, MEM_MAP, MEM_EL,
                 PULL_EXISTS]
         \\ fs [Once (DECIDE “A ⇒ ¬B ⇔ B ⇒ ¬A”)]
         >- (
           rpt (first_x_assum (drule_then assume_tac))
           \\ Cases_on ‘eval_to (k - 1) (EL n ys)’
-          \\ gs [CaseEqs ["sum", "v"]])
+          \\ gs [CaseEqs ["sum", "v"]]
+          \\ rename1 ‘v_rel _ w’
+          \\ Cases_on ‘w’ \\ gs [])
         \\ rpt (first_x_assum (drule_then assume_tac))
         \\ Cases_on ‘eval_to (k - 1) (EL n ys)’
         \\ gvs [CaseEqs ["sum", "v"], v_rel_Thunk_def])

--- a/compiler/backend/proofs/thunk_untickProofScript.sml
+++ b/compiler/backend/proofs/thunk_untickProofScript.sml
@@ -13,22 +13,6 @@ val _ = new_theory "thunk_untickProof";
 
 val _ = numLib.prefer_num ();
 
-(* TODO
- * I think the semantics should have a result_map which behaves like the one
- * below. It doesn't make sense that the semantics of an erroneous expression,
- * which happens to contain a diverging expression, is not Error!
- *)
-
-Theorem result_map_def:
-  result_map f xs =
-    let ys = MAP f xs in
-      if MEM (INL Type_error) ys then INL Type_error
-      else if MEM (INL Diverge) ys then INL Diverge
-      else INR (MAP OUTR ys)
-Proof
-  cheat
-QED
-
 Definition is_Lam_def[simp]:
   is_Lam (Lam s x) = T ∧
   is_Lam _ = F

--- a/compiler/backend/proofs/thunk_untickProofScript.sml
+++ b/compiler/backend/proofs/thunk_untickProofScript.sml
@@ -338,37 +338,6 @@ Proof
   \\ Cases_on ‘s1’ \\ Cases_on ‘s2’ \\ gs []
 QED
 
-Theorem result_map_Diverge[local]:
-  xs ≠ [] ⇒ result_map (λx. INL Diverge) xs = INL Diverge
-Proof
-  rw [result_map_def, MEM_MAP]
-  \\ Cases_on ‘xs’ \\ gs [SF DNF_ss]
-QED
-
-Theorem result_map_NIL[simp,local]:
-  result_map f [] = INR []
-Proof
-  rw [result_map_def]
-QED
-
-Theorem result_map_SING[local]:
-  result_map f [x] =
-    case f x of
-      INR r => INR [r]
-    | INL e => INL e
-Proof
-  rw [result_map_def]
-  \\ CASE_TAC \\ gs []
-  \\ rename1 ‘err ≠ _’
-  \\ Cases_on ‘err’ \\ gs []
-QED
-
-Theorem err_inv_nchotomy:
-  ¬(x ≠ Diverge ∧ x ≠ Type_error)
-Proof
-  rw [err_nchotomy, Once DISJ_COMM]
-QED
-
 Theorem exp_rel_eval_to:
   ∀k x y.
     exp_rel x y ∧

--- a/compiler/backend/thunkLang_primitivesScript.sml
+++ b/compiler/backend/thunkLang_primitivesScript.sml
@@ -71,12 +71,9 @@ End
 Definition result_map_def:
   result_map f xs =
     let ys = MAP f xs in
-      if MEM (INL Diverge) ys then
-        INL Diverge
-      else if MEM (INL Type_error) ys then
-        INL Type_error
-      else
-        INR (MAP OUTR ys)
+      if MEM (INL Type_error) ys then INL Type_error
+      else if MEM (INL Diverge) ys then INL Diverge
+      else INR (MAP OUTR ys)
 End
 
 Definition can_def:

--- a/meta-theory/pure_congruenceScript.sml
+++ b/meta-theory/pure_congruenceScript.sml
@@ -1639,9 +1639,11 @@ Proof
     simp[Once unfold_rel_def, eval_wh_Prim_alt] >> strip_tac >>
     Cases_on `k = 0` >> gvs[]
     >- (
-      Cases_on `xs` >> gvs[get_atoms_def] >>
-      Cases_on `eval_op a []` >> gvs[pure_configTheory.eval_op_SOME]
-      ) >>
+      gs [get_atoms_def, EXISTS_MAP, EVERY_MAP, MEM_MAP, MAP_MAP_o,
+          combinTheory.o_DEF]
+      \\ gs [EVERY_MEM, EXISTS_MEM]
+      \\ Cases_on ‘xs’ \\ gvs [SF DNF_ss]
+      \\ Cases_on ‘eval_op a []’ \\ gvs [pure_configTheory.eval_op_SOME]) >>
     Cases_on `get_atoms (MAP (λa. eval_wh_to (k − 1) a) xs)` >> gvs[] >>
     drule get_atoms_eval_wh_SOME >> strip_tac >> gvs[] >>
     CASE_TAC >> gvs[] >>
@@ -1660,28 +1662,26 @@ Proof
       ) >>
     qsuff_tac `get_atoms (MAP eval_wh es') = SOME NONE` >> gvs[] >>
     pop_assum mp_tac >> simp[get_atoms_SOME_NONE_eq] >> strip_tac >>
+    pop_assum mp_tac >>
+    rw [EXISTS_MAP, EXISTS_MEM, MEM_EL, PULL_EXISTS] >>
     qexists_tac `n` >> gvs[LIST_REL_EL_EQN, EL_MAP] >>
     last_assum (qspec_then `EL n xs` mp_tac) >> simp[EL_MEM] >>
     last_assum drule >> strip_tac >>
     disch_then $ drule_at Any >> gvs[EVERY_EL] >> strip_tac >>
+    ‘eval_wh_to (k - 1) (EL n xs) ≠ wh_Diverge ’
+      by (Cases_on ‘eval_wh_to (k - 1) (EL n xs) = wh_Diverge ’ >> gs []) >>
     `∀a. eval_wh (EL n xs) ≠ wh_Atom a` by (
       CCONTR_TAC >> gvs[] >> gvs[eval_wh_eq] >>
       first_x_assum (qspec_then `n` assume_tac) >> gvs[] >>
       drule eval_wh_to_agree >>
-      disch_then (qspec_then `k'` assume_tac) >> gvs[]) >>
+      disch_then (qspec_then `k'` assume_tac) >> gvs[] >>
+      Cases_on ‘eval_wh_to (k - 1) (EL n xs)’ >> gvs[]) >>
     `eval_wh (EL n xs) ≠ wh_Diverge` by (
       gvs[eval_wh_neq_Diverge] >>
-      first_x_assum (qspec_then `n` assume_tac) >> gvs[] >>
       goal_assum drule) >>
-    rw[] >- (Cases_on `eval_wh (EL n xs)` >> gvs[]) >>
+    gs [] >>
     first_x_assum drule >> strip_tac >>
-    `eval_wh (EL m xs) ≠ wh_Diverge` by (
-      gvs[eval_wh_neq_Diverge] >> goal_assum drule) >>
-    last_x_assum (qspec_then `EL m xs` mp_tac) >> simp[EL_MEM] >>
-    disch_then drule >>
-    `m < LENGTH es'` by gvs[] >> res_tac >>
-    disch_then drule >> simp[] >>
-    strip_tac >> Cases_on `eval_wh (EL m xs)` >> gvs[]
+    Cases_on ‘eval_wh (EL n xs)’ >> gvs []
     )
   >- ( (* Seq *)
     qpat_x_assum `_ ≠ wh_Diverge` mp_tac >>

--- a/meta-theory/pure_ctxt_equivScript.sml
+++ b/meta-theory/pure_ctxt_equivScript.sml
@@ -642,7 +642,7 @@ Proof
       simp[plug_def] >>
       simp[itree_of_def, semantics_def, eval_wh_thm] >>
       simp[eval_wh_Prim, pure_evalTheory.get_atoms_def] >>
-      Cases_on `eval_wh e2'` >> gvs[wh_to_cons_def]
+      Cases_on `eval_wh e2'` >> gvs[wh_to_cons_def, dest_Atom_def]
       )
     >- ( (* Str *)
       qexists_tac
@@ -650,7 +650,7 @@ Proof
       simp[plug_def] >>
       simp[itree_of_def, semantics_def, eval_wh_thm] >>
       simp[eval_wh_Prim, pure_evalTheory.get_atoms_def] >>
-      Cases_on `eval_wh e2'` >> gvs[wh_to_cons_def]
+      Cases_on `eval_wh e2'` >> gvs[wh_to_cons_def, dest_Atom_def]
       )
     >- ( (* Loc *)
       reverse $ Cases_on `∃m. eval_wh e2' = wh_Atom (Loc m)` >> gvs[]
@@ -716,7 +716,7 @@ Proof
       simp[plug_def] >>
       simp[itree_of_def, semantics_def, eval_wh_thm] >>
       simp[eval_wh_Prim, pure_evalTheory.get_atoms_def] >>
-      Cases_on `eval_wh e1'` >> gvs[wh_to_cons_def]
+      Cases_on `eval_wh e1'` >> gvs[wh_to_cons_def, dest_Atom_def]
       )
     >- ( (* Str *)
       qexists_tac
@@ -724,7 +724,7 @@ Proof
       simp[plug_def] >>
       simp[itree_of_def, semantics_def, eval_wh_thm] >>
       simp[eval_wh_Prim, pure_evalTheory.get_atoms_def] >>
-      Cases_on `eval_wh e1'` >> gvs[wh_to_cons_def]
+      Cases_on `eval_wh e1'` >> gvs[wh_to_cons_def, dest_Atom_def]
       )
     >- ( (* Loc *)
       qexists_tac `BindAllocsC (SUC n)` >>

--- a/typing/pure_typingProofScript.sml
+++ b/typing/pure_typingProofScript.sml
@@ -249,7 +249,8 @@ Proof
       CASE_TAC >> gvs[] >- simp[type_wh_cases, type_ok] >>
       CASE_TAC >> gvs[]
       >- (
-        gvs[get_atoms_SOME_NONE_eq, LIST_REL_EL_EQN, EL_MAP, MEM_EL, PULL_EXISTS] >>
+        gvs[get_atoms_SOME_NONE_eq, EXISTS_MEM, LIST_REL_EL_EQN, EL_MAP, MEM_EL,
+            PULL_EXISTS] >>
         first_x_assum drule >> strip_tac >>
         last_x_assum $ qspec_then `k - 1` mp_tac >> simp[] >>
         disch_then drule_all >> strip_tac >>


### PR DESCRIPTION
This PR changes the way the semantics prioritizes errors in pureLang and thunkLang/envLang. 

Previously, if evaluation of one of the arguments to an atomic operation diverged, then the semantics of the whole expression would be `wh_Diverge`, even if evaluation of other arguments would get stuck. This PR swaps this ordering, so that if the evaluation of one argument gets stuck, then the whole computation gets stuck, even if evaluation of another argument diverges.

The change is probably inconsequential to pureLang proofs, but it's needed it in thunkLang for the tick/untick relations. `AtomOp` is the only place where the pureLang semantics is strict, and with a clear order of evaluation, hence this change leaks to pureLang.
