### PR TITLE
Cleanup inliner

### DIFF
--- a/compiler/backend/languages/relations/pure_inline_rel_altScript.sml
+++ b/compiler/backend/languages/relations/pure_inline_rel_altScript.sml
@@ -68,7 +68,6 @@ Proof
   \\ gvs [GSYM subst_fdomsub]
 QED
 
-(* //TODO(kπ) move *)
 Theorem exp_eq_subst_IMP_exp_eq:
   (∀f. (∀n v. FLOOKUP f n = SOME v ⇒ closed v) ∧
        freevars x ⊆ FDOM f ∧ freevars y ⊆ FDOM f ⇒

--- a/meta-theory/pure_inline_relScript.sml
+++ b/meta-theory/pure_inline_relScript.sml
@@ -458,7 +458,6 @@ Proof
   \\ gvs [GSYM subst_fdomsub]
 QED
 
-(* //TODO(kπ) move *)
 Theorem exp_eq_subst_IMP_exp_eq:
   (∀f. (∀n v. FLOOKUP f n = SOME v ⇒ closed v) ∧
        freevars x ⊆ FDOM f ∧ freevars y ⊆ FDOM f ⇒


### PR DESCRIPTION
- remove `inliner_old`, `inline_all_old`, `tree_size`
- remove inliner debugs
- remove named TODOs